### PR TITLE
Cachedir fix

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -963,7 +963,7 @@ function dump_zip(url, subfileName)
 		slash = "\\"
 	end
 	
-	local tmpFileName = vlc.config.cachedir()..slash..subfileName..".gz"
+	local tmpFileName = os.tmpname()
 	local tmpFile = assert(io.open(tmpFileName, "wb"))
 		
 	tmpFile:write(resp)


### PR DESCRIPTION
> I think i fixed Issue #3 by using os.tmpname() to get a temp file instead of using vlc's cache dir.

os.tmpname() just return a random string (at least on windows if I remember correctly). I don't consider using C: as a good option, it's not safe and not clean (leave garbage file if an error occur for example).
I think it would be better to use with os.execute("mkdir " .. vlc.config.cachedir()) instead.
