### PR TITLE
Update vlsub.lua

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -710,7 +710,7 @@ function check_config()
 	lang = nil
 	lang = options.translation -- just a short cut
 	
-	if not(vlc.net or vlc.net.poll) then
+	if not vlc.net or not vlc.net.poll then
 		dlg = vlc.dialog(openSub.conf.useragent..': '..lang["mess_error"])
 		interface_no_support()
 		dlg:show()


### PR DESCRIPTION
I don't know what was meant by the condition not(vlc.net or vlc.net.poll) but it fails on vlc 2.1 because if net is nil you can't check net.poll!

I'm guessing you meant this instead.
