### PR TITLE
Don't reset selection after download

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1663,8 +1663,6 @@ function download_subtitles()
   
   openSub.actionLabel = lang["mess_downloading"] 
   
-  display_subtitles() -- reset selection
-  
   local item = openSub.itemStore[index]
   
   if openSub.option.downloadBehaviour == 'manual' 


### PR DESCRIPTION
It is very annoying when i have to try many different version of subtitles on a big list and for each try lost the selected subtitle.

When you don't remember which is the downloaded subtitle, there is no way to know it  and i have to try again with the sames.
