### PR TITLE
Multiple options to language code in file name

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -35,7 +35,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston MA 02110-1301, USA.
 local options = {
   language = nil,
   downloadBehaviour = 'save',
-  langExt = false,
+  langExt = '0 chars',
   removeTag = false,
   showMediaInformation = true,
   progressBarSize = 80,
@@ -506,6 +506,7 @@ function interface_config()
     lang["int_bool_"..tostring(not openSub.option.langExt)], 1)
   input_table['langExt']:add_value(lang["int_language_code_2"], 2)
   input_table['langExt']:add_value(lang["int_language_code_3"], 3)
+
   input_table['removeTag']:add_value(
     lang["int_bool_"..tostring(openSub.option.removeTag)], 1)
   input_table['removeTag']:add_value(
@@ -965,7 +966,8 @@ function apply_config()
   elseif input_table["langExt"]:get_value() == 3 then
     openSub.option.langExt = '3 chars'
   else
-    -- throw an exception
+    vlc.msg.err("[VLSub] Unknown language extension: " ..
+      input_table["langExt"]:get_value())
   end
   
   if input_table["removeTag"]:get_value() == 2 then
@@ -1690,7 +1692,7 @@ function download_subtitles()
   local subfileName = openSub.file.name or ""
   
   if openSub.option.langExt == '2 chars' then
-    subfileName = subfileName.."."..get_key_for_value(lang_os_to_iso, item.SubLanguageID)
+    subfileName = subfileName.."."..get_key(lang_os_to_iso, item.SubLanguageID)
   elseif openSub.option.langExt == '3 chars' then
     subfileName = subfileName.."."..item.SubLanguageID
   end
@@ -1799,7 +1801,7 @@ function dump_zip(url, dir, subfileName)
     .."!/"..subfileName, tmpFileName
 end
 
-function get_key_for_value(table, value)
+function get_key(table, value)
   for k, v in pairs(table) do
     if v == value then 
       return k

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -502,11 +502,6 @@ function interface_config()
     lang["int_save"],
     apply_config, 3, 10, 1, 1)
   
-  input_table['langExt']:add_value(
-    lang["int_bool_"..tostring(not openSub.option.langExt)], 1)
-  input_table['langExt']:add_value(lang["int_language_code_2"], 2)
-  input_table['langExt']:add_value(lang["int_language_code_3"], 3)
-
   input_table['removeTag']:add_value(
     lang["int_bool_"..tostring(openSub.option.removeTag)], 1)
   input_table['removeTag']:add_value(
@@ -528,6 +523,8 @@ function interface_config()
     'downloadBehaviour',
     openSub.conf.downloadBehaviours,
     1)
+
+  assoc_select_conf('langExt', 'langExt', openSub.conf.langExt, 1)
 end
 
 function interface_help()
@@ -836,6 +833,8 @@ function check_config()
     setError(lang["mess_err_conf_access"])
   end
     
+  set_language_code_file()
+
   -- Set table list of available translations from assoc. array 
   -- so it is sortable
   
@@ -1073,6 +1072,15 @@ function SetDownloadBehaviours()
   openSub.conf.downloadBehaviours = { 
     {'save', lang["int_dowload_save"]},
     {'manual', lang["int_dowload_manual"]}
+  }
+end
+
+function set_language_code_file() -- ap
+  openSub.conf.langExt = nil
+  openSub.conf.langExt = {
+    { '0 chars', lang["int_bool_false"] },
+    { '2 chars', lang["int_language_code_2"] },
+    { '3 chars', lang["int_language_code_3"] }
   }
 end
 

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -91,6 +91,8 @@ local options = {
     int_vlsub_work_dir = 'VLSub working directory',
     int_os_username = 'Username',
     int_os_password = 'Password',
+    int_language_code_2 = 'Yes (2 chars)',
+    int_language_code_3 = 'Yes (3 chars)',
     int_help_mess =[[
       Download subtitles from 
       <a href='http://www.opensubtitles.org/'>
@@ -501,9 +503,9 @@ function interface_config()
     apply_config, 3, 10, 1, 1)
   
   input_table['langExt']:add_value(
-    lang["int_bool_"..tostring(openSub.option.langExt)], 1)
-  input_table['langExt']:add_value(
-    lang["int_bool_"..tostring(not openSub.option.langExt)], 2)
+    lang["int_bool_"..tostring(not openSub.option.langExt)], 1)
+  input_table['langExt']:add_value(lang["int_language_code_2"], 2)
+  input_table['langExt']:add_value(lang["int_language_code_3"], 3)
   input_table['removeTag']:add_value(
     lang["int_bool_"..tostring(openSub.option.removeTag)], 1)
   input_table['removeTag']:add_value(
@@ -956,8 +958,14 @@ function apply_config()
   openSub.option.os_username = input_table['os_username']:get_text()
   openSub.option.os_password = input_table['os_password']:get_text()
   
-  if input_table["langExt"]:get_value() == 2 then
-    openSub.option.langExt = not openSub.option.langExt
+  if input_table["langExt"]:get_value() == 1 then
+    openSub.option.langExt = '0 chars'
+  elseif input_table["langExt"]:get_value() == 2 then
+    openSub.option.langExt = '2 chars'
+  elseif input_table["langExt"]:get_value() == 3 then
+    openSub.option.langExt = '3 chars'
+  else
+    -- throw an exception
   end
   
   if input_table["removeTag"]:get_value() == 2 then
@@ -1681,7 +1689,9 @@ function download_subtitles()
   local message = ""
   local subfileName = openSub.file.name or ""
   
-  if openSub.option.langExt then
+  if openSub.option.langExt == '2 chars' then
+    subfileName = subfileName.."."..get_key_for_value(lang_os_to_iso, item.SubLanguageID)
+  elseif openSub.option.langExt == '3 chars' then
     subfileName = subfileName.."."..item.SubLanguageID
   end
   
@@ -1787,6 +1797,16 @@ function dump_zip(url, dir, subfileName)
   collectgarbage()
   return "zip://"..make_uri(tmpFileName)
     .."!/"..subfileName, tmpFileName
+end
+
+function get_key_for_value(table, value)
+  for k, v in pairs(table) do
+    if v == value then 
+      return k
+    end
+  end
+
+  return nil
 end
 
 function add_sub(subPath)

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -958,11 +958,11 @@ function apply_config()
   openSub.option.os_username = input_table['os_username']:get_text()
   openSub.option.os_password = input_table['os_password']:get_text()
   
-  if input_table["langExt"]:get_value() == 1 then
+  if input_table["langExt"]:get_text() == lang["int_bool_false"] then
     openSub.option.langExt = '0 chars'
-  elseif input_table["langExt"]:get_value() == 2 then
+  elseif input_table["langExt"]:get_text() == lang["int_language_code_2"] then
     openSub.option.langExt = '2 chars'
-  elseif input_table["langExt"]:get_value() == 3 then
+  elseif input_table["langExt"]:get_text() == lang["int_language_code_3"] then
     openSub.option.langExt = '3 chars'
   else
     vlc.msg.err("[VLSub] Unknown language extension: " ..


### PR DESCRIPTION
Hello, im doing a modification because i want to select the language code for the file in iso-639-1 or iso-639-3. For example i need to use the extension .es.srt instead of .spa.srt.

Now I think that is working fine.
