### PR TITLE
Fix download on MAC/LINUX

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1777,10 +1777,14 @@ function dump_zip(url, dir, subfileName)
   local tmpFileName = dir..subfileName..".gz"
   if not file_touch(tmpFileName) then
     vlc.msg.dbg("[VLsub] Cant touch:"..tmpFileName)
-    -- using tmp dir to download
-    tmpFileName = "/tmp/"..subfileName..".gz"
-    vlc.msg.dbg("[VLsub] Fixing to:"..tmpFileName)
-    --return false
+    if openSub.conf.os == "win" then
+      -- todo for windows
+      return false
+    else
+      -- using tmp dir to download
+      tmpFileName = "/tmp/"..subfileName..".gz"
+      vlc.msg.dbg("[VLsub] Fixing to:"..tmpFileName)
+    end
   end
   local tmpFile = assert(io.open(tmpFileName, "wb"))
   

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1776,7 +1776,11 @@ function dump_zip(url, dir, subfileName)
   
   local tmpFileName = dir..subfileName..".gz"
   if not file_touch(tmpFileName) then
-    return false
+    vlc.msg.dbg("[VLsub] Cant touch:"..tmpFileName)
+    -- using tmp dir to download
+    tmpFileName = "/tmp/"..subfileName..".gz"
+    vlc.msg.dbg("[VLsub] Fixing to:"..tmpFileName)
+    --return false
   end
   local tmpFile = assert(io.open(tmpFileName, "wb"))
   


### PR DESCRIPTION
Workaround to fix download of zip in MAC/LINUX, in case it cant be writen in directory ..

Example: when you are opening a file from samba server.
