### PR TITLE
fixes exebetche/vlc#71 and fixes exebetche/vlc#121

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -414,7 +414,7 @@ function interface_main()
   dlg:add_button(
     lang["int_dowload_sel"], download_subtitles, 3, 7, 1, 1)
   dlg:add_button(
-    lang["int_close"], deactivate, 4, 7, 1, 1) 
+    lang["int_close"], close, 4, 7, 1, 1) 
   
   assoc_select_conf(
     'language',


### PR DESCRIPTION
I don't know the implementation of vlc, but from what I observed :
- when you use the extension menu and extension has never been opened, it opens the extension
- when you use the extension menu and extension is currently opened, it closes the extension

According to the logs :
- when you close the extension with the extension menu, a signal like this one is sent : Extension thread end: 'VLsub 0.9.13'
- when you close the extension with the default close button (top of the window), a signal like this one is sent : Extension thread end: 'VLsub 0.9.13'
- when you close the extension with the custom "close" button at the bottom, no signal is sent

Therefore, the bug happens as follow :
- when you use the extension menu and extension has never been opened, it opens the extension
- when you close the extension with the custom "close" button at the bottom, no signal is sent
- when you use the extension menu and extension is currently opened, it closes the extension --> instead of opening it like the user wants to, because the signal wasn't sent when we clicked on the "close" button

Note that the close function triggers this signal, and the deactivate function doesn't.

To fix this bug, the close button is now bound to the vlc global close function instead of the vlc global deactivate function.