### PR TITLE
Fixes for remote MRL

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1482,13 +1482,22 @@ openSub = {
       return false 
     end
     
+    local infoString = openSub.file.cleanName
+    if infoString == '' or infoString == nil then
+      -- read from meta-title
+      local metas = vlc.input.item():metas()
+      if metas['title'] ~= nil then
+        infoString = metas['title']
+      end
+    end
+
     local showName, seasonNumber, episodeNumber = string.match(
-      openSub.file.cleanName,
+      infoString,
       "(.+)[sS](%d?%d)[eE](%d%d).*")
 
     if not showName then
       showName, seasonNumber, episodeNumber = string.match(
-      openSub.file.cleanName,
+      infoString,
       "(.-)(%d?%d)[xX](%d%d).*")
     end
     
@@ -1497,7 +1506,7 @@ openSub = {
       openSub.movie.seasonNumber = seasonNumber
       openSub.movie.episodeNumber = episodeNumber
     else
-      openSub.movie.title = openSub.file.cleanName
+      openSub.movie.title = infoString
       openSub.movie.seasonNumber = ""
       openSub.movie.episodeNumber = ""
     end

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1452,6 +1452,9 @@ openSub = {
         file.is_archive = false
       end
       
+      if file.completeName == nil then
+        file.completeName = ''
+      end
       file.name, file.ext = string.match(
         file.completeName,
         '^([^/]-)%.?([^%.]*)$')

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1483,14 +1483,26 @@ openSub = {
     end
     
     local infoString = openSub.file.cleanName
-    if infoString == '' or infoString == nil then
+    if infoString == nil then
+      infoString = ''
+    end
+    
+    if infoString == '' then
       -- read from meta-title
+      local meta = vlc.var.get(vlc.object.input(), 'meta-title')
+      if meta ~= nil then
+        infoString = meta
+      end
+    end
+    
+    if infoString == '' then
+      -- read from metadata
       local metas = vlc.input.item():metas()
       if metas['title'] ~= nil then
         infoString = metas['title']
       end
     end
-
+    
     local showName, seasonNumber, episodeNumber = string.match(
       infoString,
       "(.+)[sS](%d?%d)[eE](%d%d).*")

--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1832,6 +1832,7 @@ function add_sub(subPath)
   if vlc.item or vlc.input.item() then
     subPath = decode_uri(subPath)
     vlc.msg.dbg("[VLsub] Adding subtitle :" .. subPath)
+    vlc.var.set(vlc.object.input(), 'sub-file', subPath)
     return vlc.input.add_subtitle(subPath)
   end
   return false


### PR DESCRIPTION
- Fix download path when MRL is remote and possibly contains only query string.
- Try to use vlc --meta-title option and/or metadata for search term in case of remote  MRL.
