### PR TITLE
unbreak VLSub by making http requests refer to HTTP/1.0

### DIFF
--- a/vlsub.lua
+++ b/vlsub.lua
@@ -1200,7 +1200,7 @@ openSub = {
     local request = "<?xml version='1.0'?>"..dump_xml(reqTable)
     local host, path = parse_url(openSub.conf.url)		
     local header = {
-      "POST "..path.." HTTP/1.1", 
+      "POST "..path.." HTTP/1.0",
       "Host: "..host, 
       "User-Agent: "..openSub.conf.userAgentHTTP, 
       "Content-Type: text/xml", 
@@ -1877,7 +1877,7 @@ end
 function get(url)
   local host, path = parse_url(url)
   local header = {
-    "GET "..path.." HTTP/1.1", 
+    "GET "..path.." HTTP/1.0",
     "Host: "..host, 
     "User-Agent: "..openSub.conf.userAgentHTTP,
     "",


### PR DESCRIPTION
Cloudflare now uses chunked encoding for clients that support HTTP/1.1.  Since VLSub doesn’t actually support chunked encoding, let’s just update the HTTP requests to report HTTP/1.0.  This more accurately represents the client’s capabilities and seems to fix the extension. See: https://github.com/exebetche/vlsub/issues/143